### PR TITLE
Don't hide cache variables.

### DIFF
--- a/cmake/FetchDawn.cmake
+++ b/cmake/FetchDawn.cmake
@@ -63,29 +63,37 @@ if (NOT dawn_POPULATED)
 		set(USE_VULKAN ON)
 		set(USE_METAL OFF)
 	endif()
-	set(DAWN_ENABLE_D3D11 OFF)
-	set(DAWN_ENABLE_D3D12 OFF)
-	set(DAWN_ENABLE_METAL ${USE_METAL})
-	set(DAWN_ENABLE_NULL OFF)
-	set(DAWN_ENABLE_DESKTOP_GL OFF)
-	set(DAWN_ENABLE_OPENGLES OFF)
-	set(DAWN_ENABLE_VULKAN ${USE_VULKAN})
-	set(TINT_BUILD_SPV_READER OFF)
+	set(DAWN_ENABLE_D3D11 OFF CACHE BOOL "Enable compilation of the D3D11 backend")
+	set(DAWN_ENABLE_D3D12 OFF CACHE BOOL "Enable compilation of the D3D12 backend")
+	set(DAWN_ENABLE_METAL ${USE_METAL} CACHE BOOL "Enable compilation of the Metal backend")
+	set(DAWN_ENABLE_NULL OFF CACHE BOOL "Enable compilation of the Null backend")
+	set(DAWN_ENABLE_DESKTOP_GL OFF CACHE BOOL "Enable compilation of the OpenGL backend")
+	set(DAWN_ENABLE_OPENGLES OFF CACHE BOOL "Enable compilation of the OpenGL ES backend")
+	set(DAWN_ENABLE_VULKAN ${USE_VULKAN} CACHE BOOL "Enable compilation of the Vulkan backend")
+	set(TINT_BUILD_SPV_READER OFF CACHE BOOL "Build the SPIR-V input reader")
+	if(${DAWN_ENABLE_D3D11} OR ${DAWN_ENABLE_D3D12})
+		set(TINT_BUILD_HLSL_WRITER ON CACHE BOOL "Build the HLSL output writer" FORCE)
+	endif()
+	if(${DAWN_ENABLE_DESKTOP_GL} OR ${DAWN_ENABLE_OPENGLES})
+		set(TINT_BUILD_GLSL_WRITER ON CACHE BOOL "Build the GLSL output writer" FORCE)
+	endif()
+	if(${DAWN_ENABLE_VULKAN})
+		set(TINT_BUILD_SPV_WRITER ON CACHE BOOL "Build the SPIR-V output writer" FORCE)
+	endif()
+	if(${DAWN_ENABLE_METAL})
+		set(TINT_BUILD_MSL_WRITER ON CACHE BOOL "Build the MSL output writer" FORCE)
+	endif()
 
 	# Disable unneeded parts
-	set(DAWN_BUILD_SAMPLES OFF)
-	set(TINT_BUILD_TINT OFF)
-	set(TINT_BUILD_SAMPLES OFF)
-	set(TINT_BUILD_DOCS OFF)
-	set(TINT_BUILD_TESTS OFF)
-	set(TINT_BUILD_FUZZERS OFF)
-	set(TINT_BUILD_SPIRV_TOOLS_FUZZER OFF)
-	set(TINT_BUILD_AST_FUZZER OFF)
-	set(TINT_BUILD_REGEX_FUZZER OFF)
-	set(TINT_BUILD_BENCHMARKS OFF)
-	set(TINT_BUILD_TESTS OFF)
-	set(TINT_BUILD_AS_OTHER_OS OFF)
-	set(TINT_BUILD_REMOTE_COMPILE OFF)
+	set(DAWN_BUILD_SAMPLES OFF CACHE BOOL "Enables building Dawn's samples")
+	set(TINT_BUILD_TINTD OFF CACHE BOOL "Build the WGSL language server")
+	set(TINT_BUILD_TESTS OFF CACHE BOOL "Build tests")
+	set(TINT_BUILD_FUZZERS OFF CACHE BOOL "Build fuzzers")
+	set(TINT_BUILD_AST_FUZZER OFF CACHE BOOL "Build AST fuzzer")
+	set(TINT_BUILD_REGEX_FUZZER OFF CACHE BOOL "Build regex fuzzer")
+	set(TINT_BUILD_IR_FUZZER OFF CACHE BOOL "Build IR fuzzer")
+	set(TINT_BUILD_BENCHMARKS OFF CACHE BOOL "Build Tint benchmarks")
+	set(TINT_BUILD_AS_OTHER_OS OFF CACHE BOOL "Override OS detection to force building of *_other.cc files")
 
 	add_subdirectory(${dawn_SOURCE_DIR} ${dawn_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
@@ -125,8 +133,13 @@ set(AllDawnTargets
 	tint_lang_core_ir_transform
 	tint_lang_core_ir_transform_common
 	tint_lang_core_type
-	tint_lang_glsl_validate
+	tint_lang_glsl_writer
+	tint_lang_glsl_writer_common
+	tint_lang_glsl_writer_printer
+	tint_lang_glsl_writer_ast_printer
+	tint_lang_glsl_writer_ast_raise
 	tint_lang_glsl_writer_raise
+	tint_lang_glsl_validate
 	tint_lang_hlsl_writer_common
 	tint_lang_hlsl_writer_helpers
 	tint_lang_msl
@@ -168,9 +181,12 @@ set(AllDawnTargets
 	tint_lang_wgsl_writer_ir_to_program
 	tint_lang_wgsl_writer_raise
 	tint_lang_wgsl_writer_syntax_tree_printer
-    tint_lang_core_common
-    tint_lang_hlsl_writer_printer
-    tint_lang_hlsl_writer_raise
+	tint_lang_core_common
+	tint_lang_hlsl_writer
+	tint_lang_hlsl_writer_ast_printer
+	tint_lang_hlsl_writer_ast_raise
+	tint_lang_hlsl_writer_printer
+	tint_lang_hlsl_writer_raise
 	tint_utils_bytes
 	tint_utils_cli
 	tint_utils_command


### PR DESCRIPTION
This commit prevents cache variables from being hidden in the CMake GUI.
Also, if specific backends are enabled, force the appropriate writers to be built to prevent compiler & linker errors (this really should be done in the Dawn library, but it's not!).