### PR TITLE
Ignore whitespace when applying patch

### DIFF
--- a/cmake/FetchDawn.cmake
+++ b/cmake/FetchDawn.cmake
@@ -43,7 +43,7 @@ FetchContent_Declare(
 		git reset --hard FETCH_HEAD
 
 	PATCH_COMMAND
-		git apply "${CMAKE_CURRENT_LIST_DIR}/../patch/dawn.patch"
+		git apply --ignore-space-change --ignore-whitespace "${CMAKE_CURRENT_LIST_DIR}/../patch/dawn.patch"
 )
 
 FetchContent_GetProperties(dawn)


### PR DESCRIPTION
I believe differing whitespace was causing the cmake project generation to fail on windows. They failed both on my machine and on my github CI, with the following error message:

```
  1>Checking Build System
  No update step for 'dawn-populate'
  Building Custom Rule C:/Dev/OpenGL/OpenGL/build/_deps/dawn-subbuild/CMakeLists.txt
  Performing patch step for 'dawn-populate'
CUSTOMBUILD : error : patch failed: tools/fetch_dawn_dependencies.py:88 [C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\dawn-populate.vcxproj]
CUSTOMBUILD : error : tools/fetch_dawn_dependencies.py: patch does not apply [C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\dawn-populate.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): error MSB8066: Custom build for 'C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\129330622950a4e0f0da4883dd240834\dawn-populate-update.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\129330622950a4e0f0da4883dd240834\dawn-populate-patch.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\129330622950a4e0f0da4883dd240834\dawn-populate-configure.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\129330622950a4e0f0da4883dd240834\dawn-populate-build.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\129330622950a4e0f0da4883dd240834\dawn-populate-install.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\129330622950a4e0f0da4883dd240834\dawn-populate-test.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\313edad76fa1c357ee99429dc1a178af\dawn-populate-complete.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeFiles\944f518010a464a380ea8c00f25811c5\dawn-populate.rule;C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\CMakeLists.txt' exited with code 1. [C:\Dev\OpenGL\OpenGL\build\_deps\dawn-subbuild\dawn-populate.vcxproj]

CMake Error at C:/Program Files/CMake/share/cmake-3.30/Modules/FetchContent.cmake:1918 (message):
  Build step for dawn failed: 1
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.30/Modules/FetchContent.cmake:1609 (__FetchContent_populateSubbuild)
  C:/Program Files/CMake/share/cmake-3.30/Modules/FetchContent.cmake:2145:EVAL:2 (__FetchContent_doPopulation)
  C:/Program Files/CMake/share/cmake-3.30/Modules/FetchContent.cmake:2145 (cmake_language)
  C:/Program Files/CMake/share/cmake-3.30/Modules/FetchContent.cmake:1978:EVAL:1 (__FetchContent_Populate)
  C:/Program Files/CMake/share/cmake-3.30/Modules/FetchContent.cmake:1978 (cmake_language)
  OpenGL/build/_deps/webgpu-src/cmake/FetchDawn.cmake:51 (FetchContent_Populate)
  OpenGL/build/_deps/webgpu-src/CMakeLists.txt:27 (include)


-- Configuring incomplete, errors occurred!
```

I see that this repository has CI that verifies that it builds on windows, so I'm not sure why it failed for me but succeeded elsewhere. I wonder if it could somehow be a difference in git's `autocrlf` setting affecting line endings. Regardless, the change in this PR causes builds to succeed on windows, mac, and ubuntu for me. 

By the way, you can probably tell that I've been reading your book haha. I wanted to say that I really appreciate you having written it. It's clear how much effort went into creating it and the associated repositories. 