### PR TITLE
Make enum types structural and literal (dawn)

### DIFF
--- a/include-emscripten/webgpu/webgpu.hpp
+++ b/include-emscripten/webgpu/webgpu.hpp
@@ -126,11 +126,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. It also cannot be const, see [this comment](https://github.com/eliemichel/WebGPU-Cpp/pull/21#issuecomment-2408875806) */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;

--- a/include/webgpu/webgpu.hpp
+++ b/include/webgpu/webgpu.hpp
@@ -126,11 +126,9 @@ class Type { \
 public: \
 	typedef Type S; /* S == Self */ \
 	typedef WGPU ## Type W; /* W == WGPU Type */ \
-	Type(const W& w) : m_raw(w) {} \
-	operator W() const { return m_raw; } \
-private: \
-	W m_raw; \
-public:
+	constexpr Type(const W& w) : m_raw(w) {} \
+	constexpr operator W() const { return m_raw; } \
+	W m_raw; /* Ideally, this would be private, but then types generated with this macro would not be structural. It also cannot be const, see [this comment](https://github.com/eliemichel/WebGPU-Cpp/pull/21#issuecomment-2408875806) */
 
 #define ENUM_ENTRY(Name, Value) \
 	static constexpr W Name = (W)Value;


### PR DESCRIPTION
Hey, I made this change here in this PR to WebGPU-Cpp: https://github.com/eliemichel/WebGPU-Cpp/pull/21

However, it didn't seem to get copied over to the `dawn` branch here. I'm not sure how this setup works, so maybe I'm doing something wrong haha. But I thought I might as well contribute that change over to the `dawn` branch in this repo.

Happy to make an analogous version of this PR to the wgpu branch as well

P.S. I normally specify the latest revision of the `dawn` branch in my CMakeLists.txt. Is that the right way to do it? (I'm only interested in using Dawn for now)
